### PR TITLE
Needs being compatible with Python3/Django 2.0

### DIFF
--- a/src/usertools/admin.py
+++ b/src/usertools/admin.py
@@ -13,7 +13,10 @@ from django.contrib.auth.admin import UserAdmin as UserAdminBase, GroupAdmin as 
 from django.contrib import admin, auth
 from django.contrib.admin.utils import flatten_fieldsets
 from django.core.exceptions import PermissionDenied
-from django.core.urlresolvers import reverse
+try:
+    from django.core.urlresolvers import reverse
+except ModuleNotFoundError:
+    from django.urls import reverse
 from django.core.mail import send_mail
 from django.db import transaction
 from django.db.models import Count


### PR DESCRIPTION
This small fix should fix the issue with compatibility with Django 2.0, as it was throwing a ModuleNotFoundError exception at that import. Django has simply moved the reverse method.